### PR TITLE
Allow stubbing of refs

### DIFF
--- a/lib/testNode.js
+++ b/lib/testNode.js
@@ -7,6 +7,7 @@ function TestNode(element) {
   this.element = element;
 
   this.ref = this.element._reactInternalInstance._currentElement.ref;
+  this.key = this.element._reactInternalInstance._currentElement.key;
 
   this._previousRefNodes = [];
   this._previousRefCollectionKeys = [];

--- a/lib/testTree.js
+++ b/lib/testTree.js
@@ -1,19 +1,86 @@
 var React = require("react/addons");
+var _ = require("lodash");
 var utils = React.addons.TestUtils;
 var TestNode = require("./testNode");
 
-function testTree(element) {
+function testTree(element, options) {
+  options = options || {};
+
+  if (options.stub) {
+    wrapRender(element, options.stub);
+  }
+
   element = utils.renderIntoDocument(element);
 
   var rootNode = new TestNode(element);
   rootNode.dispose = dispose;
 
   return rootNode;
+}
 
-  function dispose() {
-    if (this.isMounted()) {
-      React.unmountComponentAtNode(this.getDOMNode().parentNode);
+function dispose() {
+  if (this.isMounted()) {
+    React.unmountComponentAtNode(this.getDOMNode().parentNode);
+  }
+}
+
+function wrapRender(element, stubTree) {
+  var oldRenderFn = element.type.prototype.render;
+  element.type.prototype.render = function () {
+    var renderTree = oldRenderFn.apply(this, arguments);
+    return stubRenderTree(renderTree, stubTree);
+  };
+}
+
+function stubRenderTree(renderTree, stubTree) {
+
+  return processNode(renderTree);
+
+  function stubChildren(node) {
+    var newProps = node._store.props;
+    var oldChildren = newProps.children;
+
+    if (oldChildren instanceof Array) {
+      newProps.children = _.map(oldChildren, processNode);
+    } else {
+      newProps.children = processNode(oldChildren);
     }
+
+    node._store.props =  newProps;
+    // Update originalProps to prevent mutation warning
+    node._store.originalProps = newProps;
+    return node;
+  }
+
+  function processNode(node) {
+    if (!utils.isElement(node)) {
+      return node;
+    }
+
+    var stub = stubTree[node.ref];
+    if (!stub && stub !== undefined) {
+      return null;
+    }
+
+    if (utils.isElement(stub)) {
+      // Update ref of stub to that of the original node
+      var stubProps = _.extend({}, node._store.props, stub._store.props);
+      stub._store.props = stubProps;
+      stub._store.originalProps = stubProps;
+      return React.addons.cloneWithProps(stub, {
+        ref: node.ref,
+        key: node.key
+      });
+    }
+
+    // If composite component, wrap it's render method too
+    if (typeof stub === "object" &&
+      typeof node.type.prototype.render === "function" &&
+      typeof node.type.prototype.setState === "function") {
+      wrapRender(node, stub);
+    }
+
+    return stubChildren(node);
   }
 }
 

--- a/test/fixtures/mockComponent.jsx
+++ b/test/fixtures/mockComponent.jsx
@@ -1,0 +1,9 @@
+var React = require("react");
+
+var MockComponent = React.createClass({
+  render: function () {
+    return <div>{this.props.children}</div>;
+  }
+});
+
+module.exports = MockComponent;

--- a/test/fixtures/stubbingComponent.jsx
+++ b/test/fixtures/stubbingComponent.jsx
@@ -1,0 +1,26 @@
+var React = require("react");
+
+var StubbingComponent2 = React.createClass({
+  render: function () {
+    return (
+      <div ref="fuz">
+        <button ref="buz">Buz</button>
+      </div>
+    );
+  }
+});
+
+var StubbingComponent = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <div ref="nofoo" />
+        <div ref="foo" key="foo" bar="bar">Foo</div>
+        <div ref="baz">Baz</div>
+        <StubbingComponent2 ref="boz" />
+      </div>
+    );
+  }
+});
+
+module.exports = StubbingComponent;

--- a/test/testNodeTests.jsx
+++ b/test/testNodeTests.jsx
@@ -1,0 +1,183 @@
+var React = require("react/addons");
+var expect = require("chai").expect;
+var sinon = require("sinon");
+var testTree = require("../lib/testTree");
+var TestNode = require("../lib/testNode");
+var BasicComponent = require("./fixtures/basicComponent.jsx");
+var NestedComponent = require("./fixtures/nestedComponent.jsx");
+var UnmountingComponent = require("./fixtures/unmountingComponent.jsx");
+var UnsafeComponent = require("./fixtures/unsafeComponent.jsx");
+var utils = React.addons.TestUtils;
+
+describe("TestNode", function () {
+
+  describe("by default", function () {
+    var tree;
+    before(function () {
+      tree = testTree(<BasicComponent />);
+    });
+    after(function () {
+      tree.dispose();
+    });
+
+    it("should map refs onto tree as TestNodes", function () {
+      expect(tree.foo).to.be.instanceOf(TestNode);
+    });
+
+    it("should map refCollections onto tree as arrays of TestNodes", function () {
+      expect(tree.bar).to.be.an("array");
+      expect(tree.bar[0]).to.be.an.instanceOf(TestNode);
+      expect(tree.bar[1]).to.be.an.instanceOf(TestNode);
+    });
+
+    it("should expose simulate library", function () {
+      expect(tree.simulate.click).to.exist;
+    });
+
+    it("should expose element", function () {
+      expect(utils.isCompositeComponent(tree.element)).to.be.true;
+    });
+
+    it("should expose element value", function () {
+      expect(tree.baz.value).to.equal("Baz");
+    });
+
+    it("should expose state", function () {
+      expect(tree.state).to.deep.equal({
+        foo: "bar"
+      });
+    });
+  });
+
+  describe("when unsafe ref names are supplied", function () {
+    it("should throw an error", function () {
+      var tree;
+      var fn = function () {
+        tree = testTree(<UnsafeComponent />);
+      };
+      expect(fn).to.throw(/Attempted to overwrite protected/);
+    });
+  });
+
+  describe("when nested components are supplied", function () {
+    var tree;
+    before(function () {
+      tree = testTree(<NestedComponent />);
+    });
+    after(function () {
+      tree.dispose();
+    });
+
+    it("should recursively map refs", function () {
+      expect(tree.nested.ref2).to.be.instanceOf(TestNode);
+    });
+
+    it("should recursively map refCollections", function () {
+      expect(tree.nested.refCollection2).to.be.an("array");
+      expect(tree.nested.refCollection2[0]).to.be.an.instanceOf(TestNode);
+      expect(tree.nested.refCollection2[1]).to.be.an.instanceOf(TestNode);
+    });
+
+    it("should only map refs to direct owners", function () {
+      expect(tree.ref2).to.not.exist;
+      expect(tree.nested.ref1).to.not.exist;
+    });
+
+    it("should only map refCollections to direct owners", function () {
+      expect(tree.refCollection2).to.not.exist;
+      expect(tree.nested.refCollection1).to.not.exist;
+    });
+  });
+
+  describe("when nodes update", function () {
+    var tree, bazNode, barCollectionNode;
+    before(function () {
+      tree = testTree(<BasicComponent />);
+      bazNode = tree.baz;
+      barCollectionNode = tree.bar[0];
+      tree.element.forceUpdate();
+    });
+    after(function () {
+      tree.dispose();
+    });
+
+    it("should not recreate ref nodes", function () {
+      expect(tree.baz).to.equal(bazNode);
+    });
+
+    it("should not recrate refCollection nodes", function () {
+      expect(tree.bar[0]).to.equal(barCollectionNode);
+    });
+  });
+
+  describe("when child nodes unmount", function () {
+    var tree;
+    before(function () {
+      tree = testTree(<UnmountingComponent />);
+      expect(tree.foo).to.have.length(2);
+      expect(tree.bar).to.exist;
+      expect(tree.baz).to.have.length(2);
+      tree.element.setUnmounted();
+    });
+    after(function () {
+      tree.dispose();
+    });
+
+    it("should no longer map unmounted refs onto tree", function () {
+      expect(tree.bar).to.not.exist;
+    });
+
+    it("should no longer map unmounted refCollections onto tree", function () {
+      expect(tree.baz).to.not.exist;
+    });
+
+    it("should no longer contain unmounted refCollection parts in array", function () {
+      expect(tree.foo).to.have.length(1);
+    });
+  });
+
+  describe("when node methods are called", function () {
+    var tree, spy;
+    beforeEach(function () {
+      spy = sinon.spy();
+      tree = testTree(<BasicComponent onClick={spy} />);
+    });
+    afterEach(function () {
+      tree.dispose();
+    });
+
+    it("should return DOM node", function () {
+      expect(tree.getDOMNode()).to.equal(tree.element.getDOMNode());
+    });
+
+    it("should simulate click", function () {
+      tree.click();
+      expect(spy).to.have.been.calledOnce;
+    });
+
+    it("should return attribute", function () {
+      expect(tree.getAttribute("class")).to.equal("Foo");
+    });
+
+    it("should return className", function () {
+      expect(tree.getClassName()).to.equal("Foo");
+    });
+
+    it("should return prop", function () {
+      expect(tree.getProp("onClick")).to.equal(spy);
+    });
+
+    it("should set value", function () {
+      expect(tree.baz.value).to.equal("Baz");
+      tree.baz.value = "BazFoo";
+      expect(tree.baz.value).to.equal("BazFoo");
+    });
+
+    it("should return mount state", function () {
+      expect(tree.isMounted()).to.be.true;
+      tree.dispose();
+      expect(tree.isMounted()).to.be.false;
+    });
+  });
+
+});

--- a/test/testTreeTests.jsx
+++ b/test/testTreeTests.jsx
@@ -2,11 +2,9 @@ var React = require("react/addons");
 var expect = require("chai").expect;
 var sinon = require("sinon");
 var testTree = require("../lib/testTree");
-var TestNode = require("../lib/testNode");
 var BasicComponent = require("./fixtures/basicComponent.jsx");
-var NestedComponent = require("./fixtures/nestedComponent.jsx");
-var UnmountingComponent = require("./fixtures/unmountingComponent.jsx");
-var UnsafeComponent = require("./fixtures/unsafeComponent.jsx");
+var StubbingComponent = require("./fixtures/stubbingComponent.jsx");
+var MockComponent = require("./fixtures/mockComponent.jsx");
 var utils = React.addons.TestUtils;
 
 describe("testTree", function () {
@@ -22,30 +20,8 @@ describe("testTree", function () {
       utils.renderIntoDocument.restore();
     });
 
-    it("should map refs onto tree as TestNodes", function () {
-      expect(tree.foo).to.be.instanceOf(TestNode);
-    });
-
-    it("should map refCollections onto tree as arrays of TestNodes", function () {
-      expect(tree.bar).to.be.an("array");
-      expect(tree.bar[0]).to.be.an.instanceOf(TestNode);
-      expect(tree.bar[1]).to.be.an.instanceOf(TestNode);
-    });
-
-    it("should expose simulate library", function () {
-      expect(tree.simulate.click).to.exist;
-    });
-
     it("should only render the top-level component", function () {
       expect(utils.renderIntoDocument).to.have.been.calledOnce;
-    });
-
-    it("should expose element", function () {
-      expect(utils.isCompositeComponent(tree.element)).to.be.true;
-    });
-
-    it("should expose element value", function () {
-      expect(tree.baz.value).to.equal("Baz");
     });
 
     it("should only have dispose method on root node", function () {
@@ -53,147 +29,70 @@ describe("testTree", function () {
       expect(tree.foo.dispose).to.not.exist;
     });
 
-    it("should expose state", function () {
-      expect(tree.state).to.deep.equal({
-        foo: "bar"
-      });
-    });
-
   });
 
-  describe("when unsafe ref names are supplied", function () {
-    it("should throw an error", function () {
-      var tree;
-      var fn = function () {
-        tree = testTree(<UnsafeComponent />);
-      };
-      expect(fn).to.throw(/Attempted to overwrite protected/);
-    });
-  });
-
-  describe("when nested components are supplied", function () {
-    var tree;
-    before(function () {
-      tree = testTree(<NestedComponent />);
-    });
-    after(function () {
-      tree.dispose();
-    });
-
-    it("should recursively map refs", function () {
-      expect(tree.nested.ref2).to.be.instanceOf(TestNode);
-    });
-
-    it("should recursively map refCollections", function () {
-      expect(tree.nested.refCollection2).to.be.an("array");
-      expect(tree.nested.refCollection2[0]).to.be.an.instanceOf(TestNode);
-      expect(tree.nested.refCollection2[1]).to.be.an.instanceOf(TestNode);
-    });
-
-    it("should only map refs to direct owners", function () {
-      expect(tree.ref2).to.not.exist;
-      expect(tree.nested.ref1).to.not.exist;
-    });
-
-    it("should only map refCollections to direct owners", function () {
-      expect(tree.refCollection2).to.not.exist;
-      expect(tree.nested.refCollection1).to.not.exist;
-    });
-  });
-
-  describe("when nodes update", function () {
-    var tree, bazNode, barCollectionNode;
-    before(function () {
-      tree = testTree(<BasicComponent />);
-      bazNode = tree.baz;
-      barCollectionNode = tree.bar[0];
-      tree.element.forceUpdate();
-    });
-    after(function () {
-      tree.dispose();
-    });
-
-    it("should not recreate ref nodes", function () {
-      expect(tree.baz).to.equal(bazNode);
-    });
-
-    it("should not recrate refCollection nodes", function () {
-      expect(tree.bar[0]).to.equal(barCollectionNode);
-    });
-  });
-
-  describe("when child nodes unmount", function () {
-    var tree;
-    before(function () {
-      tree = testTree(<UnmountingComponent />);
-      expect(tree.foo).to.have.length(2);
-      expect(tree.bar).to.exist;
-      expect(tree.baz).to.have.length(2);
-      tree.element.setUnmounted();
-    });
-    after(function () {
-      tree.dispose();
-    });
-
-    it("should no longer map unmounted refs onto tree", function () {
-      expect(tree.bar).to.not.exist;
-    });
-
-    it("should no longer map unmounted refCollections onto tree", function () {
-      expect(tree.baz).to.not.exist;
-    });
-
-    it("should no longer contain unmounted refCollection parts in array", function () {
-      expect(tree.foo).to.have.length(1);
-    });
-  });
-
-  describe("when tree methods are called", function () {
+  describe("when tree is disposed", function () {
     var tree, spy;
     beforeEach(function () {
-      spy = sinon.spy();
-      tree = testTree(<BasicComponent onClick={spy} />);
+      spy = sinon.spy(React, "unmountComponentAtNode");
+      tree = testTree(<BasicComponent />);
     });
     afterEach(function () {
       tree.dispose();
+      spy.restore();
     });
+
     it("should unmount component", function () {
       tree.dispose();
       expect(tree.isMounted()).to.be.false;
-    });
-
-    it("should return DOM node", function () {
-      expect(tree.getDOMNode()).to.equal(tree.element.getDOMNode());
-    });
-
-    it("should simulate click", function () {
-      tree.click();
       expect(spy).to.have.been.calledOnce;
     });
+  });
 
-    it("should return attribute", function () {
-      expect(tree.getAttribute("class")).to.equal("Foo");
+  describe("when stubbed", function () {
+    var tree;
+    before(function () {
+      var stubTree = {
+        foo: <MockComponent />,
+        baz: <MockComponent>Bazza</MockComponent>,
+        nofoo: null,
+        boz: {
+          buz: null
+        }
+      };
+      tree = testTree(<StubbingComponent />, { stub: stubTree });
     });
-
-    it("should return className", function () {
-      expect(tree.getClassName()).to.equal("Foo");
-    });
-
-    it("should return prop", function () {
-      expect(tree.getProp("onClick")).to.equal(spy);
-    });
-
-    it("should set value", function () {
-      expect(tree.baz.value).to.equal("Baz");
-      tree.baz.value = "BazFoo";
-      expect(tree.baz.value).to.equal("BazFoo");
-    });
-
-    it("should return mount state", function () {
-      expect(tree.isMounted()).to.be.true;
+    after(function () {
       tree.dispose();
-      expect(tree.isMounted()).to.be.false;
     });
+
+    it("should not render anything when stub for ref is null", function () {
+      expect(tree.nofoo).to.not.exist;
+    });
+
+    it("should stub deeply nested refs", function () {
+      expect(tree.boz.fuz).to.exist;
+      expect(tree.boz.buz).to.not.exist;
+    });
+
+    it("should stub ref with stub element if provided", function () {
+      expect(utils.isCompositeComponentWithType(tree.foo.element, MockComponent));
+      expect(utils.isCompositeComponentWithType(tree.baz.element, MockComponent));
+    });
+
+    it("should copy props from original onto stub element", function () {
+      expect(tree.foo.getProp("bar")).to.equal("bar");
+      expect(tree.foo.key).to.equal("foo");
+    });
+
+    it("should pass children to stub element", function () {
+      expect(tree.foo.getProp("children")).to.equal("Foo");
+    });
+
+    it("should use stub element's children if available", function () {
+      expect(tree.baz.getProp("children")).to.equal("Bazza");
+    });
+
   });
 
 });


### PR DESCRIPTION
Closes #5

Allows the user to stub various refs in the entire test tree. This can be very useful when you don't want to render a composite component that might trigger it's own sideways data loading, or want to render a mock child component.

__Example usage:__

```jsx
var Bar = React.createClass({
  render: function () {
    return (
      <div ref="bar">
        <button ref="baz">Button</button>
      </div>
    );
  }
});

var Boz = React.createClass({
  render: function () {
    return <div ref="boz" />;
  }
});

var Foo = React.createClass({
  render: function () {
    return (
      <div ref="foo">
        <span ref="fud">fud</span>
        <div ref="bur">
          <Bar ref="Bar" />
        </div>
      </div>
    );
  }
});

var stubTree = {
  fud: null,
  Bar: {
    baz: <Boz />
  }
};

var fooTree = testTree(<Foo />, { stub: stubTree });

fooTree.fud; // -> null
fooTree.Bar.baz.boz; // -> object
```

@jhollingworth thoughts?

__Todo:__
- [x] Tests
- [x] Update docs