### PR TITLE
Handle DOM node being null when disposing

### DIFF
--- a/lib/testTree.js
+++ b/lib/testTree.js
@@ -10,17 +10,18 @@ function testTree(element, options) {
     wrapRender(element, options.stub);
   }
 
-  element = utils.renderIntoDocument(element);
+  var container = document.createElement("div");
+  element = React.render(element, container);
 
   var rootNode = new TestNode(element);
-  rootNode.dispose = dispose;
+  rootNode.dispose = dispose.bind(rootNode, container);
 
   return rootNode;
 }
 
-function dispose() {
+function dispose(container) {
   if (this.isMounted()) {
-    React.unmountComponentAtNode(this.getDOMNode().parentNode);
+    React.unmountComponentAtNode(container);
   }
 }
 
@@ -46,7 +47,7 @@ function stubRenderTree(renderTree, stubTree) {
       newProps.children = processNode(oldChildren);
     }
 
-    node._store.props =  newProps;
+    node._store.props = newProps;
     // Update originalProps to prevent mutation warning
     node._store.originalProps = newProps;
     return node;
@@ -63,7 +64,7 @@ function stubRenderTree(renderTree, stubTree) {
     }
 
     if (utils.isElement(stub)) {
-      // Update ref of stub to that of the original node
+      // Merge old and new props onto stub
       var stubProps = _.extend({}, node._store.props, stub._store.props);
       stub._store.props = stubProps;
       stub._store.originalProps = stubProps;

--- a/test/fixtures/nullComponent.jsx
+++ b/test/fixtures/nullComponent.jsx
@@ -1,0 +1,9 @@
+var React = require("react");
+
+var NullComponent = React.createClass({
+  render: function () {
+    return null;
+  }
+});
+
+module.exports = NullComponent;

--- a/test/testTreeTests.jsx
+++ b/test/testTreeTests.jsx
@@ -5,6 +5,7 @@ var testTree = require("../lib/testTree");
 var BasicComponent = require("./fixtures/basicComponent.jsx");
 var StubbingComponent = require("./fixtures/stubbingComponent.jsx");
 var MockComponent = require("./fixtures/mockComponent.jsx");
+var NullComponent = require("./fixtures/nullComponent.jsx");
 var utils = React.addons.TestUtils;
 
 describe("testTree", function () {
@@ -12,16 +13,16 @@ describe("testTree", function () {
   describe("by default", function () {
     var tree;
     before(function () {
-      sinon.spy(utils, "renderIntoDocument");
+      sinon.spy(React, "render");
       tree = testTree(<BasicComponent />);
     });
     after(function () {
       tree.dispose();
-      utils.renderIntoDocument.restore();
+      React.render.restore();
     });
 
     it("should only render the top-level component", function () {
-      expect(utils.renderIntoDocument).to.have.been.calledOnce;
+      expect(React.render).to.have.been.calledOnce;
     });
 
     it("should only have dispose method on root node", function () {
@@ -36,9 +37,9 @@ describe("testTree", function () {
     beforeEach(function () {
       spy = sinon.spy(React, "unmountComponentAtNode");
       tree = testTree(<BasicComponent />);
+      tree.dispose();
     });
     afterEach(function () {
-      tree.dispose();
       spy.restore();
     });
 
@@ -46,6 +47,20 @@ describe("testTree", function () {
       tree.dispose();
       expect(tree.isMounted()).to.be.false;
       expect(spy).to.have.been.calledOnce;
+    });
+  });
+
+  describe("when tree of null component is disposed", function () {
+    var tree;
+    beforeEach(function () {
+      tree = testTree(<NullComponent />);
+    });
+
+    it("should unmount successfully", function () {
+      var fn = function () {
+        tree.dispose();
+      };
+      expect(fn).to.not.throw;
     });
   });
 


### PR DESCRIPTION
If the root node returns null from it's render method, react-test-tree will currently throw an error when trying to unmount the component since it attempts to call getDOMNode().parentNode. We fix this by keeping a reference to the parent node from creation of the tree and using that to unmount at the end.