### PR TITLE
Allow child context to be specified by wrapping the element before rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Creates the tree and returns the root node, with all `ref` and `refCollection` n
 *__Options__*
 * `stub`: see section on [stubs](#stubs)
 * `mount`: if true, the tree's container will be mounted into the body rather than being rendered entirely in memory. Useful if you need to test various styling aspects.
+* `context`: use this option to pass through the context object required for your component. test-tree will automatically wrap your component and pass through the context.
 
 ### `rootNode.dispose()`
 Safely unmount the tree. Will only unmount if component is already mounted. Can only be called on the root node of the tree.

--- a/lib/testTree.js
+++ b/lib/testTree.js
@@ -37,7 +37,7 @@ function makeWrapper(element, context) {
     }
   });
 
-  return <Wrapper />;
+  return React.createElement(Wrapper);
 }
 
 function dispose(container) {

--- a/lib/testTree.js
+++ b/lib/testTree.js
@@ -14,12 +14,30 @@ function testTree(element, options) {
   if (options.mount) {
     document.body.appendChild(container);
   }
-  element = React.render(element, container);
+  var wrapper = React.render(makeWrapper(element, options.context), container);
 
-  var rootNode = new TestNode(element);
+  var rootNode = new TestNode(wrapper.refs.element);
   rootNode.dispose = dispose.bind(rootNode, container);
 
   return rootNode;
+}
+
+function makeWrapper(element, context) {
+  var Wrapper = React.createClass({
+    childContextTypes: _.mapValues(context, function () {
+      return React.PropTypes.any;
+    }),
+
+    getChildContext: function () {
+      return context;
+    },
+
+    render: function () {
+      return React.createElement(element.type, _.defaults({ ref: "element" }, element.props));
+    }
+  });
+
+  return <Wrapper />;
 }
 
 function dispose(container) {

--- a/test/fixtures/contextComponent.jsx
+++ b/test/fixtures/contextComponent.jsx
@@ -1,0 +1,13 @@
+var React = require("react");
+
+var ContextComponent = React.createClass({
+  contextTypes: {
+    foo: React.PropTypes.string,
+    bar: React.PropTypes.number
+  },
+  render: function () {
+    return null;
+  }
+});
+
+module.exports = ContextComponent;

--- a/test/testTreeTests.jsx
+++ b/test/testTreeTests.jsx
@@ -6,6 +6,7 @@ var BasicComponent = require("./fixtures/basicComponent.jsx");
 var StubbingComponent = require("./fixtures/stubbingComponent.jsx");
 var MockComponent = require("./fixtures/mockComponent.jsx");
 var NullComponent = require("./fixtures/nullComponent.jsx");
+var ContextComponent = require("./fixtures/contextComponent.jsx");
 var utils = React.addons.TestUtils;
 
 describe("testTree", function () {
@@ -61,6 +62,24 @@ describe("testTree", function () {
         tree.dispose();
       };
       expect(fn).to.not.throw;
+    });
+  });
+
+  describe("when context is supplied", function () {
+    var tree, context;
+    before(function () {
+      context = {
+        foo: "Foos",
+        bar: 12345
+      };
+      tree = testTree(<ContextComponent />, { context: context });
+    });
+    after(function () {
+      tree.dispose();
+    });
+
+    it("should pass context context through to component", function () {
+      expect(tree.element.context).to.deep.equal(context);
     });
   });
 


### PR DESCRIPTION
@jhollingworth this should solve #12 . It will allow you to simply do:

```jsx
var context = {
  foo: "bar"
};
testTree(<Baz />, { context: context });
```

This is achieved by using a wrapper component to re-create the element with a proper context.

Closes #15 