### PR TITLE
Get protectedProperties using getOwnPropertyNames instead of _.keys

### DIFF
--- a/lib/testNode.js
+++ b/lib/testNode.js
@@ -46,7 +46,7 @@ function TestNode(element) {
     }
   });
 
-  var protectedProperties = _.keys(this);
+  var protectedProperties = Object.getOwnPropertyNames(this);
 
   updateRefs(this);
   updateRefCollections(this);

--- a/test/fixtures/unsafeComponent.jsx
+++ b/test/fixtures/unsafeComponent.jsx
@@ -2,7 +2,7 @@ var React = require("react");
 
 var UnsafeComponent = React.createClass({
   render: function () {
-    return <div ref="element" />;
+    return <div ref="value" />;
   }
 });
 


### PR DESCRIPTION
Ensures that properties declared with Object.defineProperty are also protected

@giuse88 

Closes #9 