### PR TITLE
Update Manager

### DIFF
--- a/lib/testNode.js
+++ b/lib/testNode.js
@@ -2,7 +2,7 @@ var _ = require("lodash");
 var React = require("react/addons");
 var utils = React.addons.TestUtils;
 
-function TestNode(element) {
+function TestNode(element, updateManager) {
 
   this.element = element;
 
@@ -52,6 +52,7 @@ function TestNode(element) {
   updateRefCollections(this);
 
   wrapComponentDidUpdate(this);
+  wrapShouldComponentUpdate(this);
 
   function wrapComponentDidUpdate(node) {
     var oldComponentDidUpdate = node.element.componentDidUpdate;
@@ -62,6 +63,15 @@ function TestNode(element) {
       if (oldComponentDidUpdate) {
         oldComponentDidUpdate.apply(this, arguments);
       }
+      updateManager.nodeHasUpdated(node);
+    };
+  }
+
+  function wrapShouldComponentUpdate(node) {
+    var oldShouldComponentUpdate = node.element.shouldComponentUpdate || _.constant(true);
+
+    node.element.shouldComponentUpdate = function () {
+      return updateManager.shouldNodeUpdate(node) && oldShouldComponentUpdate.apply(this, arguments);
     };
   }
 
@@ -69,7 +79,7 @@ function TestNode(element) {
     var nextRefs = node.element.refs;
 
     var nextRefNodes = _.map(nextRefs, function (nextRef, refKey) {
-      var nextRefNode = node[refKey] || new TestNode(nextRef);
+      var nextRefNode = node[refKey] || new TestNode(nextRef, updateManager);
       ensureSafeRefName(refKey);
       node[refKey] = nextRefNode;
       return nextRefNode;
@@ -104,7 +114,7 @@ function TestNode(element) {
         var previousNode = _.find(node[refKey], function (previousNode) {
           return previousNode.element === child;
         });
-        return previousNode || new TestNode(child);
+        return previousNode || new TestNode(child, updateManager);
       });
 
       return refKey;

--- a/lib/testTree.js
+++ b/lib/testTree.js
@@ -2,6 +2,7 @@ var React = require("react/addons");
 var _ = require("lodash");
 var utils = React.addons.TestUtils;
 var TestNode = require("./testNode");
+var UpdateManager = require("./updateManager");
 
 function testTree(element, options) {
   options = options || {};
@@ -16,7 +17,7 @@ function testTree(element, options) {
   }
   var wrapper = React.render(makeWrapper(element, options.context), container);
 
-  var rootNode = new TestNode(wrapper.refs.element);
+  var rootNode = new TestNode(wrapper.refs.element, new UpdateManager(wrapper.refs.element));
   rootNode.dispose = dispose.bind(rootNode, container);
 
   return rootNode;

--- a/lib/updateManager.js
+++ b/lib/updateManager.js
@@ -1,0 +1,28 @@
+function UpdateManager(rootElement) {
+  this._rootElement = rootElement;
+  this._isInternalUpdate = false;
+  this._internalUpdateSourceNode = null;
+}
+
+UpdateManager.prototype = {
+
+  _handleInternalUpdateEnd: function () {
+    this._isInternalUpdate = false;
+    this._internalUpdateSourceNode = null;
+  },
+
+  nodeHasUpdated: function (node) {
+    if (!this._isInternalUpdate) {
+      this._internalUpdateSourceNode = node;
+      this._isInternalUpdate = true;
+      this._rootElement.forceUpdate(this._handleInternalUpdateEnd.bind(this));
+    }
+  },
+
+  shouldNodeUpdate: function (node) {
+    return !this._isInternalUpdate || node !== this._internalUpdateSourceNode;
+  }
+
+};
+
+module.exports = UpdateManager;


### PR DESCRIPTION
This should hopefully fix #21 @TvoroG

The idea here is to trigger a force-update of the entire tree when a component updates. An infinite loop is prevented by tracking when we are doing an internal force update. To be as performant as possible we don't force update the component that originally updated.

@jhollingworth can you see any issues with double rendering everything?