### PR TITLE
List Simulate() methods for lazy people searching to find them quickly

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Returns the state of your component.
 Getter/setter for the element value. Should only be used if the component is a valid HTML element that accepts the value attribute.
 
 ### `node.simulate`
-Instance of `React.addons.TestUtils.Simulate`, bound to the node.
+Instance of `React.addons.TestUtils.Simulate`, bound to the node. All its methods (beforeInput, blur, change, click, compositionEnd, compositionStart, compositionUpdate, contextMenu, copy, cut, doubleClick, drag, dragEnd, dragEnter, dragExit, dragLeave, dragOver, dragStart, drop, error, focus, input, keyDown, keyPress, keyUp, load, mouseDown, mouseEnter, mouseLeave, mouseMove, mouseOut, mouseOver, mouseUp, paste, reset, scroll, select, submit, touchCancel, touchEnd, touchMove, touchStart, wheel) can be called.
 
 ### `node.click()`
 Shorthand method for simulating a click on the node's element.


### PR DESCRIPTION
A heuristic is to search on the page for doubleClick. I did this and assumed it was not supported (because `click()` was listed, and `doubleClick()` not).