### PR TITLE
:memo: Add clarifying example to README section on

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Getter/setter for the element value. Should only be used if the component is a v
 ### `node.simulate`
 Instance of `React.addons.TestUtils.Simulate`, bound to the node. All its methods (beforeInput, blur, change, click, compositionEnd, compositionStart, compositionUpdate, contextMenu, copy, cut, doubleClick, drag, dragEnd, dragEnter, dragExit, dragLeave, dragOver, dragStart, drop, error, focus, input, keyDown, keyPress, keyUp, load, mouseDown, mouseEnter, mouseLeave, mouseMove, mouseOut, mouseOver, mouseUp, paste, reset, scroll, select, submit, touchCancel, touchEnd, touchMove, touchStart, wheel) can be called.
 
+For example, to simulate double-clicking a node called `myButton`, use:
+
+```javascript
+myButton.simulate.doubleClick();
+```
+
 ### `node.click()`
 Shorthand method for simulating a click on the node's element.
 


### PR DESCRIPTION
As per my [comments on issue #33](https://github.com/QubitProducts/react-test-tree/issues/33#issuecomment-126957177), I had found the docs a bit confusing on the usage of `node.simulate`. I figured it out with some trial and error, and added an illustrative example to the docs to help future users avoid similar confusion.

Hope that's helpful! Keep up the great work!