### PR TITLE
Add ability to skip higher order components

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,41 @@ __Notes__:
 * Mock components are rendered with the new props (and children) of the mock component merged into the original props (and children) of the stubbed ref. This behaviour is demonstrated in the example above; `baz` will log `hello` and have the child `Baz`, whilst `boz` will log `foobar` and have the child `Bazza`.
 
 
+## Higher Order Components
+The HOC pattern is rapidly becoming the most popular successor to mixins (and the [problems associated with them](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750)). Unfortunately every HOC adds another layer into the component tree, making your testing ref chains longer and less explicit. `react-test-tree` can help alleviate this pain by skipping any component that has the `innerComponentRef` property available on its constructor. Here is an example:
+
+```jsx
+var InnerComponent = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <button ref="span" />
+      </div>
+    )
+  }
+});
+
+function withHOC(Component) {
+  return React.createClass({
+    render: function () {
+      return <Component ref="innerComponent" />;
+    }
+  });
+}
+
+var MyComponent = withHOC(InnerComponent);
+
+// Without specifying `innerComponentRef` we have to deal with the HOC in the ref tree
+var annoyingTree = testTree(<MyComponent />);
+annoyingTree.innerComponent.button.click();
+
+// Adding `innerComponentRef` causes react-test-tree to ignore the HOC, keeping the API nice and clean
+MyComponent.innerComponentRef = "innerComponent";
+var niceTree = testTree(<MyComponent />);
+niceTree.button.click();
+```
+
+
 ## API
 
 ### `testTree(<Component />, {options})`

--- a/lib/testNode.js
+++ b/lib/testNode.js
@@ -4,6 +4,11 @@ var utils = React.addons.TestUtils;
 
 function TestNode (element, updateManager) {
 
+  var innerComponentRef = _.get(element, "constructor.innerComponentRef");
+  if (innerComponentRef) {
+    return new TestNode(element.refs[innerComponentRef], updateManager);
+  }
+
   this.element = element;
 
   this.ref = this.element._reactInternalInstance._currentElement.ref;

--- a/lib/testNode.js
+++ b/lib/testNode.js
@@ -4,7 +4,7 @@ var utils = React.addons.TestUtils;
 
 function TestNode (element, updateManager) {
 
-  var innerComponentRef = _.get(element, "constructor.innerComponentRef");
+  var innerComponentRef = _.get(element, 'constructor.innerComponentRef');
   if (innerComponentRef) {
     return new TestNode(element.refs[innerComponentRef], updateManager);
   }

--- a/lib/testTree.js
+++ b/lib/testTree.js
@@ -51,6 +51,12 @@ function dispose (container) {
 }
 
 function wrapRender (element, stubTree) {
+  var innerComponentRef = _.get(element, 'type.innerComponentRef');
+  if (innerComponentRef) {
+    var hocStubTree = {};
+    hocStubTree[innerComponentRef] = stubTree;
+    stubTree = hocStubTree;
+  }
   var oldRenderFn = element.type.prototype.render;
   element.type.prototype.render = function () {
     var renderTree = oldRenderFn.apply(this, arguments);

--- a/test/fixtures/higherOrderComponent.jsx
+++ b/test/fixtures/higherOrderComponent.jsx
@@ -1,0 +1,23 @@
+var React = require('react');
+
+var InnerComponent = React.createClass({
+  render: function () {
+    return (
+      <div>
+        <span ref='innerSpan' />
+      </div>
+    );
+  }
+});
+
+var HigherOrderComponent = React.createClass({
+  render: function () {
+    return (
+      <InnerComponent ref='innerComponent' />
+    );
+  }
+});
+
+HigherOrderComponent.innerComponentRef = 'innerComponent';
+
+module.exports = HigherOrderComponent;

--- a/test/fixtures/stubbingComponent.jsx
+++ b/test/fixtures/stubbingComponent.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var HigherOrderComponent = require('./higherOrderComponent.jsx');
 
 var StubbingComponent2 = React.createClass({
   render: function () {
@@ -18,6 +19,7 @@ var StubbingComponent = React.createClass({
         <div ref='foo' key='foo' bar='bar'>Foo</div>
         <div ref='baz'>Baz</div>
         <StubbingComponent2 ref='boz' />
+        <HigherOrderComponent ref='hoc' />
       </div>
     );
   }

--- a/test/testNodeTests.jsx
+++ b/test/testNodeTests.jsx
@@ -8,6 +8,7 @@ var TestNode = require('../lib/testNode');
 var BasicComponent = require('./fixtures/basicComponent.jsx');
 var NestedComponent = require('./fixtures/nestedComponent.jsx');
 var UnmountingComponent = require('./fixtures/unmountingComponent.jsx');
+var HigherOrderComponent = require('./fixtures/higherOrderComponent.jsx');
 var UnsafeComponent = require('./fixtures/unsafeComponent.jsx');
 var utils = React.addons.TestUtils;
 
@@ -205,6 +206,21 @@ describe('TestNode', function () {
       expect(tree.isMounted()).to.be.true;
       tree.dispose();
       expect(tree.isMounted()).to.be.false;
+    });
+  });
+
+  describe.only('when a higher order component is found', function () {
+    var tree;
+    beforeEach(function () {
+      tree = testTree(<HigherOrderComponent />);
+    });
+    afterEach(function () {
+      tree.dispose();
+    });
+
+    it('should skip the HOC and go direct to the inner component', function () {
+      expect(tree.innerComponent).to.not.exist;
+      expect(tree.innerSpan).to.exist;
     });
   });
 

--- a/test/testNodeTests.jsx
+++ b/test/testNodeTests.jsx
@@ -209,7 +209,7 @@ describe('TestNode', function () {
     });
   });
 
-  describe.only('when a higher order component is found', function () {
+  describe('when a higher order component is found', function () {
     var tree;
     beforeEach(function () {
       tree = testTree(<HigherOrderComponent />);

--- a/test/testTreeTests.jsx
+++ b/test/testTreeTests.jsx
@@ -85,7 +85,7 @@ describe('testTree', function () {
     });
   });
 
-  describe('when stubbed', function () {
+  describe.only('when stubbed', function () {
     var tree;
     before(function () {
       var stubTree = {
@@ -94,6 +94,9 @@ describe('testTree', function () {
         nofoo: null,
         boz: {
           buz: null
+        },
+        hoc: {
+          innerSpan: <MockComponent />
         }
       };
       tree = testTree(<StubbingComponent />, { stub: stubTree });
@@ -112,8 +115,8 @@ describe('testTree', function () {
     });
 
     it('should stub ref with stub element if provided', function () {
-      expect(utils.isCompositeComponentWithType(tree.foo.element, MockComponent));
-      expect(utils.isCompositeComponentWithType(tree.baz.element, MockComponent));
+      expect(utils.isCompositeComponentWithType(tree.foo.element, MockComponent)).to.be.true;
+      expect(utils.isCompositeComponentWithType(tree.baz.element, MockComponent)).to.be.true;
     });
 
     it('should copy props from original onto stub element', function () {
@@ -129,6 +132,9 @@ describe('testTree', function () {
       expect(tree.baz.getProp('children')).to.equal('Bazza');
     });
 
+    it('should ignore higher order components', function () {
+      expect(utils.isCompositeComponentWithType(tree.hoc.innerSpan.element, MockComponent)).to.be.true;
+    });
   });
 
 });

--- a/test/testTreeTests.jsx
+++ b/test/testTreeTests.jsx
@@ -85,7 +85,7 @@ describe('testTree', function () {
     });
   });
 
-  describe.only('when stubbed', function () {
+  describe('when stubbed', function () {
     var tree;
     before(function () {
       var stubTree = {


### PR DESCRIPTION
Allows a component to be skipped if its constructor has the `innerComponentRef` prop.

@jhollingworth quick check, thanks :)

Closes #34 