### PR TITLE
Ensure refCollection works on composite components

### DIFF
--- a/lib/testNode.js
+++ b/lib/testNode.js
@@ -181,12 +181,13 @@ TestNode.prototype = {
 };
 
 function getDirectChildren (element) {
-  var children = element
+  var renderedComponent = element
     ._reactInternalInstance
-    ._renderedComponent
-    ._renderedChildren;
-
-  return _.map(children, function (child) {
+    ._renderedComponent;
+  if (renderedComponent._renderedComponent) {
+    renderedComponent = renderedComponent._renderedComponent;
+  }
+  return _.map(renderedComponent._renderedChildren, function (child) {
     return child._instance;
   });
 }

--- a/test/fixtures/basicComponent.jsx
+++ b/test/fixtures/basicComponent.jsx
@@ -1,5 +1,15 @@
 var React = require('react');
 
+var DumbComponent = React.createClass({
+  propTypes: {
+    children: React.PropTypes.any
+  },
+
+  render: function () {
+    return <div>{this.props.children}</div>;
+  }
+});
+
 var BasicComponent = React.createClass({
   getInitialState: function () {
     return {
@@ -17,6 +27,11 @@ var BasicComponent = React.createClass({
         <div ref='bam'>
           Bam
         </div>
+        <DumbComponent refCollection='boz'>
+          <div />
+          <div />
+          <div />
+        </DumbComponent>
       </div>
     );
   }

--- a/test/testNodeTests.jsx
+++ b/test/testNodeTests.jsx
@@ -36,6 +36,11 @@ describe('TestNode', function () {
       expect(tree.bar[1]).to.be.an.instanceOf(TestNode);
     });
 
+    it('should allow refCollections on composite components', function () {
+      expect(tree.boz).to.be.an('array');
+      expect(tree.boz).to.have.length(3);
+    });
+
     it('should expose simulate library', function () {
       expect(tree.simulate.click).to.exist;
     });


### PR DESCRIPTION
A component component acts as a sort of wrapper for the actual rendered component, so we need to grab the nested `_renderedComponent` instance before trying to retrieve the children.

Closes #43 

/cc @Blystad